### PR TITLE
Fix misleading documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ A simple and efficient NTP library for ESP32 / Arduino
 Setup:
 
 ```c++
-Mycila::NTP.setTimezone("Europe/Paris")
-Mycila::NTP.setNTPServer("pool.ntp.org")
+Mycila::NTP.setTimeZone("Europe/Paris");
+Mycila::NTP.sync("pool.ntp.org");
 ```
 
 Then query state:

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,8 +17,8 @@ A simple and efficient NTP library for ESP32 / Arduino
 Setup:
 
 ```c++
-Mycila::NTP.setTimezone("Europe/Paris")
-Mycila::NTP.setNTPServer("pool.ntp.org")
+Mycila::NTP.setTimeZone("Europe/Paris");
+Mycila::NTP.sync("pool.ntp.org");
 ```
 
 Then query state:


### PR DESCRIPTION
During my testing of this library in my arduino project, i have noticed the documentation included in `README.md` and `docs/index.md` is incorrect.